### PR TITLE
Update README screenshots to use images from drinko-learn-pics repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ Keep track of your ingredients like a professional:
 <div align="center">
   
   ### iPhone Screenshots
-  <img src="./Drinko-Artwork/Screenshots/6.5/6.5 - cocktails.png" alt="Cocktails View" width="200"/>
-  <img src="./Drinko-Artwork/Screenshots/6.5/6.5 - learn.png" alt="Learn View" width="200"/>
-  <img src="./Drinko-Artwork/Screenshots/6.5/6.5 - cabinet.png" alt="Cabinet View" width="200"/>
+  <img src="https://raw.githubusercontent.com/cilippofilia/drinko-learn-pics/main/shake.jpg" alt="Cocktails View" width="200"/>
+  <img src="https://raw.githubusercontent.com/cilippofilia/drinko-learn-pics/main/abv.jpg" alt="Learn View" width="200"/>
+  <img src="https://raw.githubusercontent.com/cilippofilia/drinko-learn-pics/main/gin.jpg" alt="Cabinet View" width="200"/>
   
   ### iPad Screenshots
-  <img src="./Drinko-Artwork/Screenshots/12.9/12.9 - cocktails.png" alt="iPad Cocktails" width="300"/>
-  <img src="./Drinko-Artwork/Screenshots/12.9/12.9 - learn.png" alt="iPad Learn" width="300"/>
-  <img src="./Drinko-Artwork/Screenshots/12.9/12.9 - cabinet.png" alt="iPad Cabinet" width="300"/>
+  <img src="https://raw.githubusercontent.com/cilippofilia/drinko-learn-pics/main/cocktail_olives.jpg" alt="iPad Cocktails" width="300"/>
+  <img src="https://raw.githubusercontent.com/cilippofilia/drinko-learn-pics/main/stir.jpg" alt="iPad Learn" width="300"/>
+  <img src="https://raw.githubusercontent.com/cilippofilia/drinko-learn-pics/main/whiskey.jpg" alt="iPad Cabinet" width="300"/>
   
 </div>
 


### PR DESCRIPTION
## Summary
This PR updates the README.md to replace local screenshot paths with images hosted in the [drinko-learn-pics](https://github.com/cilippofilia/drinko-learn-pics) repository.

## Changes
- Replaced local screenshot image paths with GitHub raw URLs from drinko-learn-pics repo
- Updated iPhone screenshots to use: `shake.jpg`, `abv.jpg`, and `gin.jpg`
- Updated iPad screenshots to use: `cocktail_olives.jpg`, `stir.jpg`, and `whiskey.jpg`

## Details
The images are now hosted on GitHub's CDN, making them visible in the README when viewed on GitHub. The selected images are contextually relevant to each section:
- **Cocktails**: Shaking technique and cocktail garnishes
- **Learn**: ABV calculator and stirring techniques  
- **Cabinet**: Spirit examples (gin, whiskey)

This ensures the README displays properly for all viewers without requiring local image files.