### PR TITLE
Fix Cabinet rows hidden behind cross-promo banner

### DIFF
--- a/DrinkoPro/Views/Cabinet/CabinetView.swift
+++ b/DrinkoPro/Views/Cabinet/CabinetView.swift
@@ -25,15 +25,19 @@ struct CabinetView: View {
 
     var body: some View {
         NavigationStack {
-            if categories.isEmpty {
-                unavailableView
-            } else {
-                categoriesList
-                    .navigationTitle("Cabinet")
+            Group {
+                if categories.isEmpty {
+                    unavailableView
+                } else {
+                    categoriesList
+                        .navigationTitle("Cabinet")
+                }
             }
-        }
-        .safeAreaInset(edge: .bottom) {
-            CrossPromoBannerView()
+            #if os(iOS)
+            .safeAreaInset(edge: .bottom) {
+                CrossPromoBannerView()
+            }
+            #endif
         }
     }
 }


### PR DESCRIPTION
Move the bottom safeAreaInset that hosts CrossPromoBannerView inside the
NavigationStack (matching Learn and Cocktails). Applied to the outside of
the NavigationStack, the banner's height was not reserved within the
scrolling List, leaving the last rows obscured by the ad banner.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_015M1ozCxcAq2PmW8Xv9cPbN